### PR TITLE
Optimise solvers for speed and time CGMRES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+plots

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 plots
+*/tmp/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Structure preserving iterative linear solvers
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7419815.svg)](https://doi.org/10.5281/zenodo.7419815)
 
 **This repository is a suppliment to _[“Preconditioned Krylov solvers for structure-preserving discretisations”](https://doi.org/10.48550/arXiv.2212.05127)_, and contains a conservative GMRES implementation in addition to experiments for various constrained linear systems.**
 
@@ -34,13 +35,15 @@ We consider a variety of test problems, which are self contained within subfolde
 
 **[Evolve.py](docs/experiments.md#evolve.py)**: _Generates a solution over all time steps using a given linear solver. Outputs the global deviation in conserved quantities. Sometimes also outputs errors over time._
 
+**TimedSolve.py**: _Runs timed CGMRES solves for variable problem sizes and prints a markdown style  table containing the results._
+
 **[Error generation](docs/experiments.md#error-generation)**: _This is only implemented for [Runge-Kutta formulation of linear KdV](#runge-kutta-in-time) and is composed of `ErrorGenerator.py` (generates errors in parallel), `subcall.py` (a call to [Evolve.py](docs/experiments.md#evolve.py) using an argparser), and `ErrorPlotter.py` (generates plots by reading data written in `ErrorGenerator.py`)_
 
 **Plotting**: Almost all of the above scripts generate plots. By default, these plots will be saved to the subfolder `plots` and are not shown interactively.
 
 The additional auxiliary modules are also required, we describe them here for completeness. 
 
-**[SelfTitled.py](docs/experiments.md#selftitled.py)**: _The file sharing the name with the subfolder contains the assembly of the linear system and constraints._
+**[SelfTitled.py](docs/experiments.md#selftitled.py)**: _The file sharing the name with the subfolder contains the assembly of the linear system and objects required to build constraints._
 
 **[LinearSolver.py](docs/experiments.md#linearsolver.py)**: _Wrappers for the core solver functions given in `solvers.py`. In practice, these wrappers are only important for CGMRES to incorporate the constraints._
 
@@ -68,6 +71,7 @@ This experiments code can be found in the folder lkdv.
 | ------------------------------------- | ------------------ |
 | `SingleSolve.py`                      | :white_check_mark: |
 | `Evolve.py`                           | :white_check_mark: |
+| `TimedSolve.py`                       | :x:                |
 | `ErrorGenerator.py`/`ErrorPlotter.py` | :x:                |
 
 #### Runge-Kutta in time
@@ -78,6 +82,7 @@ These experiments can be found in lkdvRK.
 | ------------------------------------- | ------------------ |
 | `SingleSolve.py`                      | :white_check_mark: |
 | `Evolve.py`                           | :white_check_mark: |
+| `TimedSolve.py`                       | :x:                |
 | `ErrorGenerator.py`/`ErrorPlotter.py` | :white_check_mark: |
 
 ### 2D Linear rotating shallow water equations
@@ -100,6 +105,7 @@ This PDE conserves a mass $\int_\Omega \rho \ dx$ and an energy $\frac12 \int_\O
 | ------------------------------------- | ------------------ |
 | `SingleSolve.py`                      | :white_check_mark: |
 | `Evolve.py`                           | :white_check_mark: |
+| `TimedSolve.py`                       | :white_check_mark: |
 | `ErrorGenerator.py`/`ErrorPlotter.py` | :x:                |
 
 ### 2D Heat equation
@@ -115,4 +121,5 @@ which preserves mass $\int_\Omega u dx$ and dissipates energy $\frac{d}{dt} \int
 | ------------------------------------- | ------------------ |
 | `SingleSolve.py`                      | :white_check_mark: |
 | `Evolve.py`                           | :x:                |
+| `TimedSolve.py`                       | :white_check_mark: |
 | `ErrorGenerator.py`/`ErrorPlotter.py` | :x:                |

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -182,6 +182,8 @@ Wrapper for the [linear solvers](solvers.md) incorporating problem specific info
 
 When utilising CGMRES, if the solver tolerance is set to be far below machine precision (`1e-20`) the solver defaults to a [prototypical](solvers.md#prototypical-cgmres) one which enforces constraints one-by-one. If the tolerance is reasonable a more [practical algorithm](solvers.md#cgmres) is used and the constraints are enforced near convergence.
 
+[Click here to read more about the forms of the constraints.](solvers.md/#acceptedconstrainttypes).
+
 ### Input
 
 `dic`: A python dictionary generated in [SelfTitled.py](#SelfTitled.py) containing the linear system and the vectors and matrices needed to form the constraints.
@@ -200,4 +202,4 @@ When utilising CGMRES, if the solver tolerance is set to be far below machine pr
 
 ### Output
 
-The same as the output of the linear solver in [solvers.py](solvers.md). The first output is the solution given by the algorithm, while the second is a dictionary containing auxiliary information used in other components of the code. 
+The same as the output of the linear solver in [solvers.py](solvers.md). The first output is the solution given by the algorithm, while the second is a dictionary containing auxiliary information used in other components of the code.

--- a/docs/solvers.md
+++ b/docs/solvers.md
@@ -39,6 +39,16 @@ Here we use GMRES up to some user-specified tolerance `contol * tol`, and below 
 
 - `contol`: A constant larger than 1 determining when constraints should initially be enforced. Constrained solves are used when the residual is less than `contol * tol`. 
 
+#### Accepted constraint types
+
+The list of constraints `conlist` can take two different forms, and this form for each test problem can be found in [LinearSolver.py](experiments.md#linearsolver.py). In the general case, `conlist` is a list of dictionaries where an arbitrary dictionary `const` contains the constraint `const['func']` and its Jacobian `const['jac']`. General constraints are expected to depend on the initial guess $x_0$ and the preconditioned matrix obtained from Arnoldi $Z$. When optimising for speed, the constraints are input as a class containing the symmeteric matrix $M$, vector $v$ and constant $c$ for constraints of the form
+
+```math
+(x_0 + Zy)^T M (x_0 + Zy) + v^T (x_0 + Zy) + c = 0
+```
+
+where $y$ is the function we minimise in the residual minimisation step and $c$ is constant.
+
 ## Prototypical CGMRES
 
 As with CGMRES, the inputs and outputs are similar to FGMRES so we just introduce any differences here. This algorithm, given by the function `cgmres_p`, is used for testing how difficult it is to enforce constraints and follows the following procedure:

--- a/heat/LinearSolver.py
+++ b/heat/LinearSolver.py
@@ -23,35 +23,19 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
 
     
     #Define constraints
-    def const_mass(z,x0,Q):
-        X = x0 + Q @ z
-        out = np.transpose(omega) @ X - m0
-        return out
-
-    def jac_mass(z,x0,Q):
-        return np.transpose(omega) @ Q
-    
-    def const_energy(z,x0,Q):#Depends on x0 and Q
-        X = x0 + Q @ z
-        out = 0.5 * X @ M @ X + 0.25 * dt * X @ L @ X \
-            + 0.5 * dt * X @ Lz0 - old_energy
-        return out
-
-    def jac_energy(z,x0,Q):#Depends on x0 and Q
-        X = x0 + Q @ z
-        dX = Q
-        out = X @ M @ dX + 0.5 * dt * X @ L @ dX \
-            + 0.5 * dt * Lz0 @ dX
-        return out
-
-    mass = {'const': const_mass,
-            'jac': jac_mass}
-    energy = {'const': const_energy,
-              'jac': jac_energy}
-    
+    class mass:
+        def __init__(self):
+            self.M = 0 * A
+            self.v = np.transpose(omega)
+            self.c = - m0
+    class energy:
+        def __init__(self):
+            self.M = M + 0.5 * dt * L
+            self.v = 0.5 * dt * Lz0
+            self.c = - old_energy
 
     #And stuff them in a list
-    conlist = [mass,energy]
+    conlist = [mass(),energy()]
 
     #If tolerance is very small, use prototypical CGMRES to enforce
     #constraints one-by-one. This is what's being used in practice

--- a/heat/LinearSolver.py
+++ b/heat/LinearSolver.py
@@ -68,12 +68,12 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
     return out
 
 
-def gmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
+def gmresWrapper(dic,x0,k,tol=1e-50,pre=None):
     #there are no constraints, so ctol does not make sense here
     A = dic['A']
     b = dic['b']
     
     out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,
-                        pre=pre,timing=timing)
+                        pre=pre)
     
     return out

--- a/heat/LinearSolver.py
+++ b/heat/LinearSolver.py
@@ -27,6 +27,9 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None):
         X = x0 + Q @ z
         out = np.transpose(omega) @ X - m0
         return out
+
+    def jac_mass(z,x0,Q):
+        return np.transpose(omega) @ Q
     
     def const_energy(z,x0,Q):#Depends on x0 and Q
         X = x0 + Q @ z
@@ -34,9 +37,21 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None):
             + 0.5 * dt * X @ Lz0 - old_energy
         return out
 
+    def jac_energy(z,x0,Q):#Depends on x0 and Q
+        X = x0 + Q @ z
+        dX = Q
+        out = X @ M @ dX + 0.5 * dt * X @ L @ dX# \
+            #+ 0.5 * dt * Lz0 @ dX
+        return out
+
+    mass = {'const': const_mass,
+            'jac': jac_mass}
+    energy = {'const': const_energy,
+              'jac': None}
+    
 
     #And stuff them in a list
-    conlist = [const_mass,const_energy]
+    conlist = [mass,energy]
 
     #If tolerance is very small, use prototypical CGMRES to enforce
     #constraints one-by-one. This is what's being used in practice

--- a/heat/LinearSolver.py
+++ b/heat/LinearSolver.py
@@ -9,7 +9,7 @@ import sys
 sys.path.insert(0,'../')
 import solvers
 
-def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None):
+def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
 
     A = dic['A']
     b = dic['b']
@@ -40,14 +40,14 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None):
     def jac_energy(z,x0,Q):#Depends on x0 and Q
         X = x0 + Q @ z
         dX = Q
-        out = X @ M @ dX + 0.5 * dt * X @ L @ dX# \
-            #+ 0.5 * dt * Lz0 @ dX
+        out = X @ M @ dX + 0.5 * dt * X @ L @ dX \
+            + 0.5 * dt * Lz0 @ dX
         return out
 
     mass = {'const': const_mass,
             'jac': jac_mass}
     energy = {'const': const_energy,
-              'jac': None}
+              'jac': jac_energy}
     
 
     #And stuff them in a list
@@ -58,20 +58,22 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None):
     #here.
     if tol<1e-20:
         out = solvers.cgmres_p(A=A,b=b,x0=x0,k=k,
-                              conlist=conlist,
-                              pre=pre)
+                               conlist=conlist,
+                               pre=pre)
     else:
         out = solvers.cgmres(A=A,b=b,x0=x0,k=k,
-                            tol=tol,conlist=conlist,
-                            pre=pre)
+                             tol=tol,conlist=conlist,
+                             pre=pre,
+                             timing=timing)
     return out
 
 
-def gmresWrapper(dic,x0,k,tol=1e-50,pre=None):
+def gmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
     #there are no constraints, so ctol does not make sense here
     A = dic['A']
     b = dic['b']
     
-    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,pre=pre)
+    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,
+                        pre=pre,timing=timing)
     
     return out

--- a/heat/TimedSolve.py
+++ b/heat/TimedSolve.py
@@ -1,0 +1,95 @@
+#global
+from firedrake import *
+import numpy as np
+import scipy.sparse.linalg as spsla
+import matplotlib.pylab as plt
+import scipy.sparse as sps
+import pandas as pd
+import pyamg
+
+#local
+import heat
+import refd
+import LinearSolver as ls
+import visualise as vis
+
+
+#Get timings for single GMRES solve
+def time_cgmres(M=2**3,degree=1,tol=1e-7,k=20):
+    #Build system
+    params, prob = heat.linforms(degree=degree,M=M)
+    #preconditioner
+    ml = pyamg.ruge_stuben_solver(params['A'])
+    pre = ml.aspreconditioner(cycle='V')
+
+    #Get initial conditions
+    Z = prob.function_space(prob.mesh)
+    z0 = Function(Z)
+    x, y = SpatialCoordinate(prob.mesh)
+    z0.assign(project(prob.ic(x,y),Z))
+    
+    #Run a regular (more optimised GMRES solve)
+    gmres_x, solvedict = ls.gmresWrapper(params,
+                                         x0=np.zeros_like(params['b']),
+                                         k=k,
+                                         tol=tol,
+                                         pre=pre)
+    
+    #Run timed solve
+    cgmres_x, geodict = ls.cgmresWrapper(params,
+                                         x0=np.zeros_like(params['b']),
+                                         k=k,
+                                         tol=tol,
+                                         pre=pre,
+                                         timing=True)
+
+    #Check for gain in constraint enforcement (i.e., that cgmres is
+    #doing something)
+    gmres_inv = heat.compute_invariants(prob,gmres_x,z0.dat.data)
+    cgmres_inv = heat.compute_invariants(prob,cgmres_x,z0.dat.data)
+    if not (abs(cgmres_inv['mass']-params['m0']) < 2 * abs(gmres_inv['mass']-params['m0'])):
+        if not (abs(cgmres_inv['energy']-params['e0']) < 2*abs(gmres_inv['energy']-params['e0'])):
+            warning('CGMRES does not lead to a significant improvement '
+                    + 'in conservation with M=%s and tol=%s' % (M, tol))
+    #Extract timings
+    out = geodict['timings']
+    #Append additional information
+    out['unconstrained_steps'] = geodict['steps'] - out['constrained_steps']
+
+    return out
+
+
+if __name__=="__main__":
+
+    #Initialise tables
+    M = []
+    runtime = []
+    time_unconstrained = []
+    time_constrained = []
+    time_pre = []
+    time_constraint = []
+    steps_unconstrained = []
+    steps_constrained = []
+    
+    #Compute timings
+    for i in range(4,12):
+        M.append(2**i)
+        out = time_cgmres(M=M[-1])
+        runtime.append(out['runtime'])
+        time_unconstrained.append(out['iter_time_unconstrained'])
+        time_constrained.append(out['iter_time_constrained'])
+        time_constraint.append(out['constraint_building'])
+        steps_constrained.append(out['constrained_steps'])
+        steps_unconstrained.append(out['unconstrained_steps'])
+        
+    #Tabulate
+    d = {'M': M,
+         'Run time': runtime,
+         'Average unconstrained iteration time': time_unconstrained,
+         'Number of unconstrained iterations': steps_unconstrained,
+         'Average overhead from building constraints': time_constraint,
+         'Average constrained iteration time': time_constrained,
+         'Number of constrained iterations': steps_constrained}
+    df = pd.DataFrame(data=d)
+
+    print(df.to_markdown())

--- a/lkdv/LinearSolver.py
+++ b/lkdv/LinearSolver.py
@@ -29,10 +29,19 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,contol=10,timing=None):
         X = x0 + Q @ z
         out = np.transpose(omega) @ X - m0
         return out
+
+    def jac1(z,x0,Q):
+        return np.transpose(omega) @ Q
     
     def const2(z,x0,Q):
         X = x0 + Q @ z
         out = 0.5*np.transpose(X) @ M @ X - mo0
+        return out
+
+    def jac2(z,x0,Q):
+        X = x0 + Q @ z
+        dX = Q
+        out = np.transpose(X) @ M @ dX
         return out
     
     def const3(z,x0,Q):
@@ -42,8 +51,24 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,contol=10,timing=None):
             - e0
         return out
 
+    def jac3(z,x0,Q):
+        X = x0 + Q @ z
+        dX = Q
+        out = np.transpose(X) @ L @ dX \
+            - np.transpose(X) @ M @ dX
+        return out
+
+    mass = {'const': const1,
+            'jac': jac1}
+
+    momentum = {'const': const2,
+                'jac': jac2}
+
+    energy = {'const': const3,
+              'jac': jac3}
+        
     #And stuff them in an ordered list
-    conlist = [const1,const2,const3]
+    conlist = [mass,momentum,energy]
 
     #If tolerance is not crazy small, use the cgmres with a tolerance
     if tol>1e-20:

--- a/lkdv/LinearSolver.py
+++ b/lkdv/LinearSolver.py
@@ -13,7 +13,7 @@ import sys
 sys.path.insert(0,'../')
 import solvers
 
-def cgmresWrapper(dic,x0,k,tol=1e-50,contol=10):
+def cgmresWrapper(dic,x0,k,tol=1e-50,contol=10,timing=None):
 
     A = dic['A']
     b = dic['b']
@@ -48,15 +48,17 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,contol=10):
     #If tolerance is not crazy small, use the cgmres with a tolerance
     if tol>1e-20:
         out = solvers.cgmres(A=A,b=b,x0=x0,k=k,tol=tol,contol=contol,
-                      conlist=conlist)
+                             conlist=conlist,timing=timing)
     #If tolerance is set to be unrealistically small, use prototypical
     #CGMRES to enforce constraints one-by-one
     else:
+        if timing!=None:
+            raise NotImplementedError('Timings are not available for prototypical solver')
         out = solvers.cgmres_p(A=A,b=b,x0=x0,k=k,
                              conlist=conlist)
     return out
 
-def gmresWrapper(dic,x0,k,tol=1e-50,contol=None):
+def gmresWrapper(dic,x0,k,tol=1e-50,contol=None,timing=None):
 
     if contol!=None:
         warnings.warn('Contol is ignored as not used in GMRES')
@@ -64,7 +66,7 @@ def gmresWrapper(dic,x0,k,tol=1e-50,contol=None):
     A = dic['A']
     b = dic['b']
     
-    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol)
+    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,timing=timing)
     
     return out
 

--- a/lkdv/TimedSolve.py
+++ b/lkdv/TimedSolve.py
@@ -1,0 +1,61 @@
+#global
+from firedrake import *
+import numpy as np
+import sys
+import matplotlib.pylab as plt
+
+#local
+import lkdv
+import refd
+import LinearSolver as ls
+
+
+if __name__=="__main__":
+
+    #Specify tolerance to be so small prototypical CGMRES is used with
+    #no stopping criteria
+    tol=1e-8
+
+    #Set up linear system
+    params, prob = lkdv.linforms(degree=1,M=100)
+
+    k = 100
+
+    #GMRES solve
+    x, solvedict = ls.gmresWrapper(params,
+                                   x0=np.zeros_like(params['b']),
+                                   k=k,
+                                   tol=tol,
+                                   timing=True)
+    
+    print('steps = ', solvedict['steps'])
+    print('timings =', solvedict['timings'])
+    input('GMRES solve end')
+    
+    #CGMRES solve
+    x_con, geodict = ls.cgmresWrapper(params,
+                                      x0=np.zeros_like(params['b']),
+                                      k=k, tol=tol,
+                                      timing=True)
+
+    print('steps =', geodict['steps'])
+    print('timings =', geodict['timings'])
+
+    input('CGMRES solve end')
+
+
+    print('cgmres error =', np.max(np.abs(x_con-x_dir)/x_dir))
+    print('gmres error =', np.max(np.abs(x-x_dir)/x_dir))
+
+    inv = lkdv.compute_invariants(prob,x)
+    print('gmres mass deviation =', inv['mass']-params['m0'])
+    print('gmres momentum deviation =', inv['momentum']-params['mo0'])
+    print('gmres energy deviation =', inv['energy']-params['e0'])
+
+    invcon = lkdv.compute_invariants(prob,x_con)
+    print('cgmres mass deviation =', invcon['mass']-params['m0'])
+    print('cgmres momentum deviation =', invcon['momentum']-params['mo0'])
+    print('cgmres energy deviation =', invcon['energy']-params['e0'])
+
+    #Generate table of results
+    table = vis.tabulator(params,prob, [solvedict, geodict])

--- a/lkdv/lkdv.py
+++ b/lkdv/lkdv.py
@@ -5,6 +5,7 @@ Linear system set up and other lkdv specific functions
 from firedrake import *
 import numpy as np
 import matplotlib.pylab as plt
+import scipy as sp
 
 #local
 import refd
@@ -105,15 +106,18 @@ def linforms(N=100,M=50,degree=1,T=1,space='DG',zinit=None):
 
     
     #Read out A and b
-    A = assemble(lhs(F),mat_type='aij').M.values
+    A = assemble(lhs(F),mat_type='aij').M.handle.getValuesCSR()
+    A = sp.sparse.csr_matrix((A[2],A[1],A[0]))
     b = np.asarray(assemble(rhs(F)).dat.data).reshape(-1)
 
     #Get form for mass matrix
     M_form = u_trial * phi * dx
-    M = assemble(lhs(M_form),mat_type='aij').M.values
+    M = assemble(lhs(M_form),mat_type='aij').M.handle.getValuesCSR()
+    M = sp.sparse.csr_matrix((M[2],M[1],M[0]))
     #And for L
     L_form = w_trial * chi * dx
-    L = assemble(lhs(L_form),mat_type='aij').M.values
+    L = assemble(lhs(L_form),mat_type='aij').M.handle.getValuesCSR()
+    L = sp.sparse.csr_matrix((L[2],L[1],L[0]))
     #And the vector needed for finding the mass
     omega = np.asarray(assemble(phi * dx).dat.data).reshape(-1)
 

--- a/lkdvRK/LinearSolver.py
+++ b/lkdvRK/LinearSolver.py
@@ -47,8 +47,36 @@ def cgmresWrapper(dic,x0,k,prob=None,pre=None,
             - e0
         return out
 
-    #And stuff them in a list
-    conlist = [const1,const2,const3]
+    def jac1(z,x0,Q):
+        dX = lkdvRK.dz1calc(prob, Q, z0)
+        return np.transpose(omega) @ dX
+
+    def jac2(z,x0,Q):
+        X = x0 + Q @ z
+        X = lkdvRK.z1calc(prob, X, z0)
+        dX = lkdvRK.dz1calc(prob, Q, z0)
+        out = np.transpose(X) @ M @ dX
+        return out
+    
+    def jac3(z,x0,Q):
+        X = x0 + Q @ z
+        X = lkdvRK.z1calc(prob, X, z0)
+        dX = lkdvRK.dz1calc(prob, Q, z0)
+        out = np.transpose(X) @ L @ dX \
+            - np.transpose(X) @ M @ dX
+        return out
+    
+    mass = {'const': const1,
+            'jac': jac1}
+
+    momentum = {'const': const2,
+                'jac': jac2}
+
+    energy = {'const': const3,
+              'jac': jac3}
+        
+    #And stuff them in an ordered list
+    conlist = [mass,momentum,energy]
 
     #If tolerance is not very crazy small, use cgmres with a tolerance
     if tol>1e-20:

--- a/lkdvRK/LinearSolver.py
+++ b/lkdvRK/LinearSolver.py
@@ -66,13 +66,13 @@ def cgmresWrapper(dic,x0,k,prob=None,pre=None,
             - np.transpose(X) @ M @ dX
         return out
     
-    mass = {'const': const1,
+    mass = {'func': const1,
             'jac': jac1}
 
-    momentum = {'const': const2,
+    momentum = {'func': const2,
                 'jac': jac2}
 
-    energy = {'const': const3,
+    energy = {'func': const3,
               'jac': jac3}
         
     #And stuff them in an ordered list

--- a/lkdvRK/lkdvRK.py
+++ b/lkdvRK/lkdvRK.py
@@ -173,6 +173,21 @@ def z1calc(prob,zbig,z0):
 
     return z1
 
+#A function to reconstruct the derivative of z1 w.r.t z as defined in
+#the constraints in LinearSolver.py
+def dz1calc(prob,Q,z0):
+    dt = prob.dt #timestep
+    b = prob.butcher_tableau.b
+    ns = prob.ns #num of stages
+    dof = len(z0) #dof of space
+
+    #Reconstruct solution Jacobian at z1
+    dz1 = np.zeros((len(z0),np.shape(Q)[-1]))
+    for s in range(ns):
+        dz1 += dt * b[s] * Q[s*dof:(s+1)*dof,:]
+        
+    return dz1
+
 #Computes values of invariants given a vector zbig
 def compute_invariants(params,prob,zbig):
 

--- a/solvers.py
+++ b/solvers.py
@@ -105,9 +105,10 @@ def cgmres(A, b ,x0, k,
 
     if timing:
         t_start = time()
-    
-    ctol = 1e-12 #specify the tolerance to which constraints *must* be
-                 #enforced
+        ctol = 1e-10 #Lower constraint tolerance for speed
+    else:
+        ctol = 1e-12 #specify the tolerance to which constraints
+                     #*must* be enforced
     
     #If not using preconditioner, set up identity as placeholder
     if pre is None:
@@ -235,7 +236,7 @@ def cgmres(A, b ,x0, k,
                                      options={'xtol': ctol,
                                               'gtol': ctol,
                                               'barrier_tol': ctol,
-                                              'maxiter': 1e4})
+                                              'maxiter': 1e3})
                 safety = True
                 #If constraints are violated, turn off safety to avoid
                 #possible termination on next iteration

--- a/solvers.py
+++ b/solvers.py
@@ -217,7 +217,7 @@ def cgmres(A, b ,x0, k,
             y0[:-1] = yk
             
         #For the first iterations use gmres
-        if residual[-1]>contol*tol and j<k:
+        if residual[-1]>contol*tol and j<k-1:
             solve = spo.minimize(func,y0,tol=None,jac=jac,hess=hess,
                                  constraints=[],
                                  method='trust-constr',
@@ -227,8 +227,8 @@ def cgmres(A, b ,x0, k,
                                           'maxiter': 1e3})
 
         else:
+            constrained_steps += 1 #Add a constrained step
             try:
-                constrained_steps += 1 #Add a constrained step
                 solve = spo.minimize(func,y0,tol=None,jac=jac,hess=hess,
                                      constraints=clist[:],
                                      method='trust-constr',
@@ -272,10 +272,9 @@ def cgmres(A, b ,x0, k,
             if constrained_steps==0:
                 t_iter_unconstrained = (time() - t_iter_start) / steps
                 t_iter_start_constrained = time()
+            #Constrained timing
             else:
                 t_iter_constrained = (time() - t_iter_start_constrained) / constrained_steps
-                
-            
 
         if residual[-1] < tol and safety==True:
             break

--- a/swe/LinearSolver.py
+++ b/swe/LinearSolver.py
@@ -24,15 +24,30 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
         X = x0 + Q @ z
         out = np.transpose(omega) @ X - m0
         return out
+
+    def jac_mass(z,x0,Q):
+        dX = Q 
+        out = np.transpose(omega) @ dX
+        return out
     
     def const_energy(z,x0,Q):#Depends on x0 and Q
         X = x0 + Q @ z
         out = 0.5 * X @ L @ X - e0
         return out
 
+    def jac_energy(z,x0,Q):
+        X = x0 + Q @ z
+        dX = Q
+        out = 0.5 * X @ L @ dX
+        return out
+
+    mass = {'const': const_mass,
+            'jac': jac_mass}
+    energy = {'const': const_energy,
+              'jac': jac_energy}
 
     #And stuff them in a list
-    conlist = [const_mass,const_energy]
+    conlist = [mass,energy]
 
     #If tol is set to be unreasonably small, use prototypical
     #algorithm to enforce constraints one-by-one

--- a/swe/LinearSolver.py
+++ b/swe/LinearSolver.py
@@ -20,34 +20,20 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
 
     
     #Define constraints
-    def const_mass(z,x0,Q):
-        X = x0 + Q @ z
-        out = np.transpose(omega) @ X - m0
-        return out
+    class mass:
+        def __init__(self):
+            self.M = 0 * A
+            self.v = np.transpose(omega)
+            self.c = - m0
 
-    def jac_mass(z,x0,Q):
-        dX = Q 
-        out = np.transpose(omega) @ dX
-        return out
-    
-    def const_energy(z,x0,Q):#Depends on x0 and Q
-        X = x0 + Q @ z
-        out = 0.5 * X @ L @ X - e0
-        return out
-
-    def jac_energy(z,x0,Q):
-        X = x0 + Q @ z
-        dX = Q
-        out = 0.5 * X @ L @ dX
-        return out
-
-    mass = {'const': const_mass,
-            'jac': jac_mass}
-    energy = {'const': const_energy,
-              'jac': jac_energy}
-
+    class energy:
+        def __init__(self):
+            self.M = L
+            self.v = np.zeros_like(x0)
+            self.c = -e0
+            
     #And stuff them in a list
-    conlist = [mass,energy]
+    conlist = [mass(),energy()]
 
     #If tol is set to be unreasonably small, use prototypical
     #algorithm to enforce constraints one-by-one

--- a/swe/LinearSolver.py
+++ b/swe/LinearSolver.py
@@ -63,10 +63,10 @@ def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
     return out
 
 
-def gmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
+def gmresWrapper(dic,x0,k,tol=1e-50,pre=None):
     A = dic['A']
     b = dic['b']
     
-    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,pre=pre,timing=timing)
+    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,pre=pre)
     
     return out

--- a/swe/LinearSolver.py
+++ b/swe/LinearSolver.py
@@ -9,7 +9,7 @@ import sys
 sys.path.insert(0,'../')
 import solvers
 
-def cgmresWrapper(dic,x0,k,tol=1e-50):
+def cgmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
 
     A = dic['A']
     b = dic['b']
@@ -38,18 +38,20 @@ def cgmresWrapper(dic,x0,k,tol=1e-50):
     #algorithm to enforce constraints one-by-one
     if tol<1e-20:
         out = solvers.cgmres_p(A=A,b=b,x0=x0,k=k,
-                               conlist=conlist)
+                               conlist=conlist,
+                               pre=pre)
     #Otherwise use algorithm with tolerance
     else:
         out = solvers.cgmres(A=A,b=b,x0=x0,k=k,tol=tol,
-                             conlist=conlist)
+                             conlist=conlist,timing=timing,
+                             pre=pre)
     return out
 
 
-def gmresWrapper(dic,x0,k,tol=1e-50):
+def gmresWrapper(dic,x0,k,tol=1e-50,pre=None,timing=None):
     A = dic['A']
     b = dic['b']
     
-    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol)
+    out = solvers.gmres(A=A,b=b,x0=x0,k=k,tol=tol,pre=pre,timing=timing)
     
     return out

--- a/swe/TimedSolve.py
+++ b/swe/TimedSolve.py
@@ -1,0 +1,82 @@
+#global
+from firedrake import *
+import numpy as np
+import scipy.sparse.linalg as spsla
+import matplotlib.pylab as plt
+import scipy.sparse as sps
+import pandas as pd
+
+#local
+import swe
+import refd
+import LinearSolver as ls
+import visualise as vis
+
+
+#Get timings for single GMRES solve
+def time_cgmres(M=2**3,degree=1,tol=1e-7,k=20):
+    #Build system
+    params, prob = swe.linforms(degree=degree,M=M)
+    #preconditioner
+    M = sps.linalg.spilu(params['A'], drop_tol=1e-4,
+                         fill_factor=10)
+    #Run a regular (more optimised GMRES solve)
+    gmres_x, solvedict = ls.gmresWrapper(params,
+                                         x0=np.zeros_like(params['b']),
+                                         k=k,
+                                         tol=tol,
+                                         pre=M)
+    
+    #Run timed solve
+    cgmres_x, geodict = ls.cgmresWrapper(params,
+                                         x0=np.zeros_like(params['b']),
+                                         k=k,
+                                         tol=tol,
+                                         pre=M,
+                                         timing=True)
+    #Check for gain in constraint enforcement (i.e., that cgmres is
+    #doing something)
+    gmres_inv = swe.compute_invariants(prob,gmres_x)
+    cgmres_inv = swe.compute_invariants(prob,cgmres_x)
+    if not (abs(cgmres_inv['mass']-params['m0']) < 2 * abs(gmres_inv['mass']-params['m0'])):
+        if not (abs(cgmres_inv['energy']-params['e0']) < 2*abs(gmres_inv['energy']-params['e0'])):
+            warning('CGMRES does not lead to a significant improvement '
+                    + 'in conservation with M=%s and tol=%s' % (M, tol))
+    #Extract timings
+    out = geodict['timings']
+    #Append additional information
+    out['unconstrained_steps'] = geodict['steps'] - out['constrained_steps']
+
+    return out
+
+
+if __name__=="__main__":
+
+    #Initialise tables
+    M = []
+    runtime = []
+    time_unconstrained = []
+    time_constrained = []
+    steps_unconstrained = []
+    steps_constrained = []
+    
+    #Compute timings
+    for i in range(3,10):
+        M.append(2**i)
+        out = time_cgmres(M=M[-1])
+        runtime.append(out['runtime'])
+        time_unconstrained.append(out['iter_time_unconstrained'])
+        time_constrained.append(out['iter_time_constrained'])
+        steps_constrained.append(out['constrained_steps'])
+        steps_unconstrained.append(out['unconstrained_steps'])
+
+    #Tabulate
+    d = {'M': M,
+         'Run time': runtime,
+         'Average unconstrained iteration time': time_unconstrained,
+         'Number of unconstrained iterations': steps_unconstrained,
+         'Average constrained iteration time': time_constrained,
+         'Number of constrained iterations': steps_constrained}
+    df = pd.DataFrame(data=d)
+
+    print(df.to_markdown())

--- a/swe/TimedSolve.py
+++ b/swe/TimedSolve.py
@@ -14,7 +14,7 @@ import visualise as vis
 
 
 #Get timings for single GMRES solve
-def time_cgmres(M=2**3,degree=1,tol=1e-7,k=20):
+def time_cgmres(M=2**3,degree=1,tol=1e-11,k=20):
     #Build system
     params, prob = swe.linforms(degree=degree,M=M)
     #preconditioner
@@ -58,7 +58,6 @@ if __name__=="__main__":
     time_unconstrained = []
     time_constrained = []
     time_constraint = []
-    time_pre = []
     steps_unconstrained = []
     steps_constrained = []
     
@@ -69,7 +68,6 @@ if __name__=="__main__":
         runtime.append(out['runtime'])
         time_unconstrained.append(out['iter_time_unconstrained'])
         time_constrained.append(out['iter_time_constrained'])
-        time_pre.append(out['pretime'])
         time_constraint.append(out['constraint_building'])
         steps_constrained.append(out['constrained_steps'])
         steps_unconstrained.append(out['unconstrained_steps'])
@@ -77,7 +75,6 @@ if __name__=="__main__":
     #Tabulate
     d = {'M': M,
          'Run time': runtime,
-         'Preconditioning time': time_pre,
          'Average unconstrained iteration time': time_unconstrained,
          'Number of unconstrained iterations': steps_unconstrained,
          'Average overhead from building constraints': time_constraint,

--- a/swe/TimedSolve.py
+++ b/swe/TimedSolve.py
@@ -57,6 +57,8 @@ if __name__=="__main__":
     runtime = []
     time_unconstrained = []
     time_constrained = []
+    time_constraint = []
+    time_pre = []
     steps_unconstrained = []
     steps_constrained = []
     
@@ -67,14 +69,18 @@ if __name__=="__main__":
         runtime.append(out['runtime'])
         time_unconstrained.append(out['iter_time_unconstrained'])
         time_constrained.append(out['iter_time_constrained'])
+        time_pre.append(out['pretime'])
+        time_constraint.append(out['constraint_building'])
         steps_constrained.append(out['constrained_steps'])
         steps_unconstrained.append(out['unconstrained_steps'])
 
     #Tabulate
     d = {'M': M,
          'Run time': runtime,
+         'Preconditioning time': time_pre,
          'Average unconstrained iteration time': time_unconstrained,
          'Number of unconstrained iterations': steps_unconstrained,
+         'Average overhead from building constraints': time_constraint,
          'Average constrained iteration time': time_constrained,
          'Number of constrained iterations': steps_constrained}
     df = pd.DataFrame(data=d)


### PR DESCRIPTION
Rewrite `solvers.py` to speed up convergence of constrained iterations. Now using SLSQP for constrained minimisation and providing the constraint Jacobian. 

Added functionality for constraints to be of the form `x @ M @ x + x @ v + c = 0` where `M`, `v` and `c` are inputs for speed, while still allowing for more general constraints.

Add timing scripts `TimedSolve.py` for SWE and heat equation.